### PR TITLE
Simplification of code and a bit faster

### DIFF
--- a/src/docformer/dataset.py
+++ b/src/docformer/dataset.py
@@ -9,6 +9,7 @@ import torch
 from torchvision.transforms import ToTensor
 
 PAD_TOKEN_BOX = [0, 0, 0, 0]
+CLS_TOKEN_BOX = [0, 0, 0, 0]
 GRID_SIZE = 1000
 
 
@@ -201,8 +202,8 @@ def create_features(
                                                                   encoding.word_ids())
 
     # step 5: add special tokens and truncate seq. to maximum length
-    token_boxes = [[0, 0, 0, 0]] + token_boxes[:-1]
-    unnormalized_token_boxes = [[0, 0, 0, 0]] + unnormalized_token_boxes[:-1]
+    token_boxes = [CLS_TOKEN_BOX] + token_boxes[:-1]
+    unnormalized_token_boxes = [CLS_TOKEN_BOX] + unnormalized_token_boxes[:-1]
     # add CLS token manually to avoid autom. addition of SEP too (as in the paper)
     encoding["input_ids"] = [tokenizer.cls_token_id] + encoding["input_ids"][:-1]
 

--- a/src/docformer/dataset.py
+++ b/src/docformer/dataset.py
@@ -255,7 +255,7 @@ def create_features(
     # step 13: add tokens for debugging
     if extras_for_debugging:
         input_ids = encoding["mlm_labels"] if apply_mask_for_mlm else encoding["input_ids"]
-        encoding["tokens_without_padding"] = ["[CLS]"] + tokenizer.convert_ids_to_tokens(input_ids)
+        encoding["tokens_without_padding"] = tokenizer.convert_ids_to_tokens(input_ids)
         encoding["words"] = words
 
     # step 14: add extra dim for batch


### PR DESCRIPTION
The bottleneck remains the tesseract but still I tried to make it faster. If you don't find any bugs, please merge.

Key changes:

1. Use of `lru_cache`
2. Use of  `word_ids` for token-level bounding box duplication. This is a feature of `BertTokenizerFast`.